### PR TITLE
Refactor/follow conventions

### DIFF
--- a/src/main/java/org/nfactorial/newsfeed/domain/interaction/controller/FollowController.java
+++ b/src/main/java/org/nfactorial/newsfeed/domain/interaction/controller/FollowController.java
@@ -30,7 +30,7 @@ public class FollowController {
 		@AuthProfile AuthProfileDto currentProfile) {
 
 		followService.followProfile(currentProfile.profileId(), followingId);
-		return new GlobalApiResponse<>(SuccessCode.CREATED.getCode(), SuccessCode.CREATED.getMessage(), null);
+		return GlobalApiResponse.of(SuccessCode.CREATED, null);
 	}
 
 	@DeleteMapping("/api/v1/profiles/{followingId}/follows")
@@ -39,7 +39,7 @@ public class FollowController {
 		@AuthProfile AuthProfileDto currentProfile) {
 
 		followService.unFollowProfile(currentProfile.profileId(), followingId);
-		return new GlobalApiResponse<>(SuccessCode.OK.getCode(), SuccessCode.OK.getMessage(), null);
+		return GlobalApiResponse.of(SuccessCode.OK, null);
 	}
 
 	@GetMapping("/api/v1/profiles/{followingId}/followed")
@@ -47,12 +47,9 @@ public class FollowController {
 		@PathVariable Long followingId,
 		@AuthProfile AuthProfileDto currentProfile
 	) {
-		FollowStatusResponse responseDto = followService.checkFollowStatus(
-			currentProfile.profileId(),
-			followingId
-		);
-
-		return new GlobalApiResponse<>(SuccessCode.OK.getCode(), SuccessCode.OK.getMessage(), responseDto);
+		
+		FollowStatusResponse responseDto = followService.checkFollowStatus(currentProfile.profileId(), followingId);
+		return GlobalApiResponse.of(SuccessCode.OK, responseDto);
 	}
 
 	@GetMapping("/api/v1/profiles/{followerId}/followings")

--- a/src/main/java/org/nfactorial/newsfeed/domain/interaction/controller/LikeController.java
+++ b/src/main/java/org/nfactorial/newsfeed/domain/interaction/controller/LikeController.java
@@ -24,7 +24,7 @@ public class LikeController {
 		@AuthProfile AuthProfileDto currentProfile) {
 
 		likeService.addLike(postId, currentProfile.profileId());
-		return new GlobalApiResponse<>(SuccessCode.CREATED.getCode(), SuccessCode.CREATED.getMessage(), null);
+		return GlobalApiResponse.of(SuccessCode.CREATED, null);
 	}
 
 	@DeleteMapping("/api/v1/posts/{postId}/likes")
@@ -33,8 +33,6 @@ public class LikeController {
 		@AuthProfile AuthProfileDto currentProfile) {
 
 		likeService.cancelLike(postId, currentProfile.profileId());
-		return new GlobalApiResponse<>(SuccessCode.OK.getCode(), SuccessCode.OK.getMessage(), null);
+		return GlobalApiResponse.of(SuccessCode.OK, null);
 	}
-
-
 }

--- a/src/main/java/org/nfactorial/newsfeed/domain/interaction/dto/response/FollowStatusResponse.java
+++ b/src/main/java/org/nfactorial/newsfeed/domain/interaction/dto/response/FollowStatusResponse.java
@@ -1,13 +1,6 @@
 package org.nfactorial.newsfeed.domain.interaction.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class FollowStatusResponse {
-
-	private boolean isFollowing;
+public record FollowStatusResponse(boolean isFollowing) {
 
 	public static FollowStatusResponse of(boolean isFollowing) {
 		return new FollowStatusResponse(isFollowing);

--- a/src/main/java/org/nfactorial/newsfeed/domain/interaction/service/FollowService.java
+++ b/src/main/java/org/nfactorial/newsfeed/domain/interaction/service/FollowService.java
@@ -9,7 +9,7 @@ import org.nfactorial.newsfeed.domain.interaction.entity.Follow;
 import org.nfactorial.newsfeed.domain.interaction.repository.FollowRepository;
 import org.nfactorial.newsfeed.domain.profile.dto.ProfileSummaryDto;
 import org.nfactorial.newsfeed.domain.profile.entity.Profile;
-import org.nfactorial.newsfeed.domain.profile.service.ProfileService;
+import org.nfactorial.newsfeed.domain.profile.service.ProfileServiceApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class FollowService {
 
 	private final FollowRepository followRepository;
-	private final ProfileService profileService;
+	private final ProfileServiceApi profileService;
 
 	@Transactional
 	public void followProfile(Long followerId, Long followingId) {

--- a/src/main/java/org/nfactorial/newsfeed/domain/interaction/service/LikeService.java
+++ b/src/main/java/org/nfactorial/newsfeed/domain/interaction/service/LikeService.java
@@ -5,9 +5,9 @@ import org.nfactorial.newsfeed.common.exception.BusinessException;
 import org.nfactorial.newsfeed.domain.interaction.entity.Like;
 import org.nfactorial.newsfeed.domain.interaction.repository.LikeRepository;
 import org.nfactorial.newsfeed.domain.post.entity.Post;
-import org.nfactorial.newsfeed.domain.post.service.PostService;
+import org.nfactorial.newsfeed.domain.post.service.PostServiceApi;
 import org.nfactorial.newsfeed.domain.profile.entity.Profile;
-import org.nfactorial.newsfeed.domain.profile.service.ProfileService;
+import org.nfactorial.newsfeed.domain.profile.service.ProfileServiceApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,8 +18,8 @@ import lombok.RequiredArgsConstructor;
 public class LikeService {
 
 	private final LikeRepository likeRepository;
-	private final PostService postService;
-	private final ProfileService profileService;
+	private final PostServiceApi postService;
+	private final ProfileServiceApi profileService;
 
 	@Transactional
 	public void addLike(Long postId, Long profileId) {


### PR DESCRIPTION
# 관련 이슈
- close #90    

# 작업 내용
- Controller에서 GlobalApiResponse의 정적 팩토리 메소드 사용하도록 변경
- 다른 도메인의 serviceApi에 필요한 메서드 정의 확인 후 인터페이스인 serviceApi에 의존하도록 변경
- response에 사용되는 dto를 record로 변경